### PR TITLE
docker: store binaries in mounted config path for persistence between runs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN mkdir -p /var/log/supervisor /app
 
 COPY docker/ /
 
+VOLUME /app/bin
+
 # set permissions to allow non-root access
 RUN chmod -R a+rw /etc/supervisor /var/log/supervisor /app
 # remove the default supervisord.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,6 @@ RUN mkdir -p /var/log/supervisor /app
 
 COPY docker/ /
 
-VOLUME /app/bin
-
 # set permissions to allow non-root access
 RUN chmod -R a+rw /etc/supervisor /var/log/supervisor /app
 # remove the default supervisord.conf
@@ -38,4 +36,5 @@ ENV ADDRESS="" \
     STORAGE="2.0TB" \
     SETUP="false" \
     AUTO_UPDATE="true" \
-    LOG_LEVEL=""
+    LOG_LEVEL="" \
+    BINARY_DIR="/app/config/bin"

--- a/docker/app/dashboard.sh
+++ b/docker/app/dashboard.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-/app/bin/storagenode dashboard --config-dir /app/config --identity-dir /app/identity $@
+BINARY_DIR=${BINARY_DIR:-/app/config/bin}
+
+${BINARY_DIR}/storagenode dashboard --config-dir /app/config --identity-dir /app/identity $@

--- a/docker/app/dashboard.sh
+++ b/docker/app/dashboard.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./storagenode dashboard --config-dir /app/config --identity-dir /app/identity $@
+/app/bin/storagenode dashboard --config-dir /app/config --identity-dir /app/identity $@

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -11,20 +11,20 @@ get_binary() {
   binary=$1
   url=$2
   wget -O "/tmp/${binary}.zip" "${url}"
-  unzip -p "/tmp/${binary}.zip" > "/app/${binary}"
+  unzip -p "/tmp/${binary}.zip" > "/app/bin/${binary}"
   rm "/tmp/${binary}.zip"
-  chmod u+x "/app/${binary}"
+  chmod u+x "/app/bin/${binary}"
 }
 
 # install storagenode and storagenode-updater binaries
 # during run of the container to not to release new docker image
 # on each new version of the storagenode binary.
-if [ ! -f "storagenode-updater" ]; then
+if [ ! -f "/app/bin/storagenode-updater" ]; then
   echo "downloading storagenode-updater"
   get_binary storagenode-updater "$(get_default_url storagenode-updater minimum)"
 
-  if ./storagenode-updater should-update storagenode-updater \
-        --binary-location /app/storagenode-updater \
+  if /app/bin/storagenode-updater should-update storagenode-updater \
+        --binary-location /app/bin/storagenode-updater \
         --identity-dir identity \
         --version.server-address="${VERSION_SERVER_URL}" 2>/dev/null
   then
@@ -33,10 +33,11 @@ if [ ! -f "storagenode-updater" ]; then
   fi
 fi
 
-if [ ! -f "storagenode" ]; then
+if [ ! -f "/app/bin/storagenode" ]; then
   echo "downloading storagenode"
 
-  if ./storagenode-updater should-update storagenode \
+  if /app/bin/storagenode-updater should-update storagenode \
+      --binary-location /app/bin/storagenode \
       --identity-dir identity \
       --version.server-address="${VERSION_SERVER_URL}" 2>/dev/null
   then
@@ -83,15 +84,15 @@ if [ -n "${LOG_LEVEL:-}" ]; then
 fi
 
 if [ "${SETUP:-}" = "true" ]; then
-  echo "Running ./storagenode setup $SNO_RUN_PARAMS ${*}"
-  exec ./storagenode setup ${SNO_RUN_PARAMS} ${*}
+  echo "Running /app/bin/storagenode setup $SNO_RUN_PARAMS ${*}"
+  exec /app/bin/storagenode setup ${SNO_RUN_PARAMS} ${*}
 else
   sed -i \
-  "s#^command=/app/storagenode-updater\$#command=/app/storagenode-updater run --binary-location /app/storagenode ${RUN_PARAMS} #" \
+  "s#^command=/app/bin/storagenode-updater\$#command=/app/bin/storagenode-updater run --binary-location /app/bin/storagenode ${RUN_PARAMS} #" \
   /etc/supervisor/supervisord.conf
 
   sed -i \
-  "s#^command=/app/storagenode\$#command=/app/storagenode run ${SNO_RUN_PARAMS} ${*}#" \
+  "s#^command=/app/bin/storagenode\$#command=/app/bin/storagenode run ${SNO_RUN_PARAMS} ${*}#" \
   /etc/supervisor/supervisord.conf
 
   # remove explicit user flag when container is run as non-root

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+BINARY_DIR=${BINARY_DIR:-/app/config/bin}
+
 get_default_url() {
   process=$1
   version=$2
@@ -11,20 +13,21 @@ get_binary() {
   binary=$1
   url=$2
   wget -O "/tmp/${binary}.zip" "${url}"
-  unzip -p "/tmp/${binary}.zip" > "/app/bin/${binary}"
+  mkdir -p "${BINARY_DIR}"
+  unzip -p "/tmp/${binary}.zip" > "${BINARY_DIR}/${binary}"
   rm "/tmp/${binary}.zip"
-  chmod u+x "/app/bin/${binary}"
+  chmod u+x "${BINARY_DIR}/${binary}"
 }
 
 # install storagenode and storagenode-updater binaries
 # during run of the container to not to release new docker image
 # on each new version of the storagenode binary.
-if [ ! -f "/app/bin/storagenode-updater" ]; then
+if [ ! -f "${BINARY_DIR}/storagenode-updater" ]; then
   echo "downloading storagenode-updater"
   get_binary storagenode-updater "$(get_default_url storagenode-updater minimum)"
 
-  if /app/bin/storagenode-updater should-update storagenode-updater \
-        --binary-location /app/bin/storagenode-updater \
+  if ${BINARY_DIR}/storagenode-updater should-update storagenode-updater \
+        --binary-location "${BINARY_DIR}/storagenode-updater" \
         --identity-dir identity \
         --version.server-address="${VERSION_SERVER_URL}" 2>/dev/null
   then
@@ -33,11 +36,11 @@ if [ ! -f "/app/bin/storagenode-updater" ]; then
   fi
 fi
 
-if [ ! -f "/app/bin/storagenode" ]; then
+if [ ! -f "${BINARY_DIR}/storagenode" ]; then
   echo "downloading storagenode"
 
-  if /app/bin/storagenode-updater should-update storagenode \
-      --binary-location /app/bin/storagenode \
+  if ${BINARY_DIR}/storagenode-updater should-update storagenode \
+      --binary-location "${BINARY_DIR}/storagenode" \
       --identity-dir identity \
       --version.server-address="${VERSION_SERVER_URL}" 2>/dev/null
   then
@@ -84,15 +87,15 @@ if [ -n "${LOG_LEVEL:-}" ]; then
 fi
 
 if [ "${SETUP:-}" = "true" ]; then
-  echo "Running /app/bin/storagenode setup $SNO_RUN_PARAMS ${*}"
-  exec /app/bin/storagenode setup ${SNO_RUN_PARAMS} ${*}
+  echo "Running ${BINARY_DIR}/storagenode setup $SNO_RUN_PARAMS ${*}"
+  exec ${BINARY_DIR}/storagenode setup ${SNO_RUN_PARAMS} ${*}
 else
   sed -i \
-  "s#^command=/app/bin/storagenode-updater\$#command=/app/bin/storagenode-updater run --binary-location /app/bin/storagenode ${RUN_PARAMS} #" \
+  "s#^command=/app/bin/storagenode-updater\$#command=${BINARY_DIR}/storagenode-updater run --binary-location ${BINARY_DIR}/storagenode ${RUN_PARAMS} #" \
   /etc/supervisor/supervisord.conf
 
   sed -i \
-  "s#^command=/app/bin/storagenode\$#command=/app/bin/storagenode run ${SNO_RUN_PARAMS} ${*}#" \
+  "s#^command=/app/bin/storagenode\$#command=${BINARY_DIR}/storagenode run ${SNO_RUN_PARAMS} ${*}#" \
   /etc/supervisor/supervisord.conf
 
   # remove explicit user flag when container is run as non-root

--- a/docker/etc/supervisor/supervisord.conf
+++ b/docker/etc/supervisor/supervisord.conf
@@ -19,7 +19,7 @@ username=dummy
 password=dummy
 
 [program:storagenode-updater]
-command=/app/storagenode-updater
+command=/app/bin/storagenode-updater
 autostart=%(ENV_AUTO_UPDATE)s
 autorestart=true
 environment=STORJ_ENV_PREFIX=STORJUPDATER
@@ -29,7 +29,7 @@ stderr_logfile=/dev/stdout
 stderr_logfile_maxbytes=0
 
 [program:storagenode]
-command=/app/storagenode
+command=/app/bin/storagenode
 autorestart=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Related #23 

To test, 
- build the docker image:

    ```
    docker buildx build -f Dockerfile -t node:latest .
    ```

- Create a directory as a test mount point:
    ```
    mkdir testmp
    ```
- Run the container, and wait till the binaries are downloaded:
    ```
    docker run --rm --name test --mount type=bind,source="/path/to/testmp",destination=/app/config node:latest
    ```
- Check that the `testmp` contains both binaries in "testmp/bin"
- Rerun the container; binaries should not be downloaded again.
