### PR TITLE
fixed exec issue for restricted systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,5 +37,4 @@ ENV ADDRESS="" \
     SETUP="false" \
     AUTO_UPDATE="true" \
     LOG_LEVEL="" \
-    BINARY_DIR="/app/bin" \
-    BINARY_STORE="/app/config/bin"
+    BINARY_STORE_DIR="/app/config/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,5 @@ ENV ADDRESS="" \
     SETUP="false" \
     AUTO_UPDATE="true" \
     LOG_LEVEL="" \
-    BINARY_DIR="/app/config/bin"
+    BINARY_DIR="/app/bin" \
+    BINARY_STORE="/app/config/bin"

--- a/docker/app/dashboard.sh
+++ b/docker/app/dashboard.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-BINARY_DIR=${BINARY_DIR:-/app/config/bin}
+BINARY_DIR=${BINARY_DIR:-/app/bin}
 
 ${BINARY_DIR}/storagenode dashboard --config-dir /app/config --identity-dir /app/identity $@

--- a/docker/app/dashboard.sh
+++ b/docker/app/dashboard.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-BINARY_DIR=${BINARY_DIR:-/app/bin}
-
-${BINARY_DIR}/storagenode dashboard --config-dir /app/config --identity-dir /app/identity $@
+/app/bin/storagenode dashboard --config-dir /app/config --identity-dir /app/identity $@

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -29,15 +29,19 @@ get_binary() {
 should_update() {
   binary=$1
   copy_binary ${binary}
-  if ${BINARY_DIR}/storagenode-updater should-update ${binary} \
-        --binary-location "${BINARY_DIR}/${binary}" \
-        --identity-dir identity \
-        --version.server-address="${VERSION_SERVER_URL}" 2>/dev/null
-  then
-    echo "downloading ${binary}"
-    get_binary ${binary} "$(get_default_url ${binary} suggested)"
-    copy_binary ${binary}
-  fi
+  for version in minimum suggested; do
+    if ${BINARY_DIR}/storagenode-updater should-update ${binary} \
+          --binary-location "${BINARY_DIR}/${binary}" \
+          --identity-dir identity \
+          --version.server-address="${VERSION_SERVER_URL}" 2>/dev/null
+    then
+      echo "downloading ${binary}"
+      get_binary ${binary} "$(get_default_url ${binary} ${version})"
+      copy_binary ${binary}
+    else
+      break
+    fi
+  done
 }
 
 # install storagenode and storagenode-updater binaries

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -24,7 +24,20 @@ get_binary() {
   mkdir -p "${BINARY_STORE}"
   unzip -p "/tmp/${binary}.zip" > "${BINARY_STORE}/${binary}"
   rm "/tmp/${binary}.zip"
-  copy_binary $binary
+}
+
+should_update() {
+  binary=$1
+  copy_binary ${binary}
+  if ${BINARY_DIR}/storagenode-updater should-update ${binary} \
+        --binary-location "${BINARY_DIR}/${binary}" \
+        --identity-dir identity \
+        --version.server-address="${VERSION_SERVER_URL}" 2>/dev/null
+  then
+    echo "downloading ${binary}"
+    get_binary ${binary} "$(get_default_url ${binary} suggested)"
+    copy_binary ${binary}
+  fi
 }
 
 # install storagenode and storagenode-updater binaries
@@ -33,34 +46,14 @@ get_binary() {
 if [ ! -f "${BINARY_STORE}/storagenode-updater" ]; then
   echo "downloading storagenode-updater"
   get_binary storagenode-updater "$(get_default_url storagenode-updater minimum)"
-
-  if ${BINARY_DIR}/storagenode-updater should-update storagenode-updater \
-        --binary-location "${BINARY_DIR}/storagenode-updater" \
-        --identity-dir identity \
-        --version.server-address="${VERSION_SERVER_URL}" 2>/dev/null
-  then
-    echo "updating storagenode-updater"
-    get_binary storagenode-updater "$(get_default_url storagenode-updater suggested)"
-  fi
-else
-  copy_binary storagenode-updater
 fi
+should_update storagenode-updater
 
 if [ ! -f "${BINARY_STORE}/storagenode" ]; then
   echo "downloading storagenode"
-
-  if ${BINARY_DIR}/storagenode-updater should-update storagenode \
-      --binary-location "${BINARY_DIR}/storagenode" \
-      --identity-dir identity \
-      --version.server-address="${VERSION_SERVER_URL}" 2>/dev/null
-  then
-    get_binary storagenode "$(get_default_url storagenode suggested)"
-  else
-    get_binary storagenode "$(get_default_url storagenode minimum)"
-  fi
-else
-  copy_binary storagenode
+  get_binary storagenode "$(get_default_url storagenode minimum)"
 fi
+should_update storagenode
 
 SUPERVISOR_SERVER="${SUPERVISOR_SERVER:-unix}"
 

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-BINARY_DIR=${BINARY_DIR:-/app/bin}
-BINARY_STORE=${BINARY_STORE:-/app/config/bin}
+BINARY_DIR=/app/bin
+BINARY_STORE_DIR=${BINARY_STORE_DIR:-/app/config/bin}
 
 get_default_url() {
   process=$1
@@ -13,7 +13,7 @@ get_default_url() {
 copy_binary() {
   binary=$1
   mkdir -p "${BINARY_DIR}"
-  cp "${BINARY_STORE}/${binary}" "${BINARY_DIR}/${binary}"
+  cp "${BINARY_STORE_DIR}/${binary}" "${BINARY_DIR}/${binary}"
   chmod u+x "${BINARY_DIR}/${binary}"
 }
 
@@ -21,8 +21,8 @@ get_binary() {
   binary=$1
   url=$2
   wget -O "/tmp/${binary}.zip" "${url}"
-  mkdir -p "${BINARY_STORE}"
-  unzip -p "/tmp/${binary}.zip" > "${BINARY_STORE}/${binary}"
+  mkdir -p "${BINARY_STORE_DIR}"
+  unzip -p "/tmp/${binary}.zip" > "${BINARY_STORE_DIR}/${binary}"
   rm "/tmp/${binary}.zip"
 }
 
@@ -48,7 +48,7 @@ should_update() {
 # during run of the container to not to release new docker image
 # on each new version of the storagenode binary.
 for binary in storagenode-updater storagenode; do
-  if [ ! -f "${BINARY_STORE}/${binary}" ]; then
+  if [ ! -f "${BINARY_STORE_DIR}/${binary}" ]; then
     echo "downloading ${binary}"
     get_binary ${binary} "$(get_default_url ${binary} minimum)"
   fi

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-BINARY_DIR=${BINARY_DIR:-/app/config/bin}
+BINARY_DIR=${BINARY_DIR:-/app/bin}
+BINARY_STORE=${BINARY_STORE:-/app/config/bin}
 
 get_default_url() {
   process=$1
@@ -9,20 +10,27 @@ get_default_url() {
   wget -O- "${VERSION_SERVER_URL}/processes/${process}/${version}/url?os=linux&arch=${GOARCH}"
 }
 
+copy_binary() {
+  binary=$1
+  mkdir -p "${BINARY_DIR}"
+  cp "${BINARY_STORE}/${binary}" "${BINARY_DIR}/${binary}"
+  chmod u+x "${BINARY_DIR}/${binary}"
+}
+
 get_binary() {
   binary=$1
   url=$2
   wget -O "/tmp/${binary}.zip" "${url}"
-  mkdir -p "${BINARY_DIR}"
-  unzip -p "/tmp/${binary}.zip" > "${BINARY_DIR}/${binary}"
+  mkdir -p "${BINARY_STORE}"
+  unzip -p "/tmp/${binary}.zip" > "${BINARY_STORE}/${binary}"
   rm "/tmp/${binary}.zip"
-  chmod u+x "${BINARY_DIR}/${binary}"
+  copy_binary $binary
 }
 
 # install storagenode and storagenode-updater binaries
 # during run of the container to not to release new docker image
 # on each new version of the storagenode binary.
-if [ ! -f "${BINARY_DIR}/storagenode-updater" ]; then
+if [ ! -f "${BINARY_STORE}/storagenode-updater" ]; then
   echo "downloading storagenode-updater"
   get_binary storagenode-updater "$(get_default_url storagenode-updater minimum)"
 
@@ -34,9 +42,11 @@ if [ ! -f "${BINARY_DIR}/storagenode-updater" ]; then
     echo "updating storagenode-updater"
     get_binary storagenode-updater "$(get_default_url storagenode-updater suggested)"
   fi
+else
+  copy_binary storagenode-updater
 fi
 
-if [ ! -f "${BINARY_DIR}/storagenode" ]; then
+if [ ! -f "${BINARY_STORE}/storagenode" ]; then
   echo "downloading storagenode"
 
   if ${BINARY_DIR}/storagenode-updater should-update storagenode \
@@ -48,6 +58,8 @@ if [ ! -f "${BINARY_DIR}/storagenode" ]; then
   else
     get_binary storagenode "$(get_default_url storagenode minimum)"
   fi
+else
+  copy_binary storagenode
 fi
 
 SUPERVISOR_SERVER="${SUPERVISOR_SERVER:-unix}"

--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -47,17 +47,13 @@ should_update() {
 # install storagenode and storagenode-updater binaries
 # during run of the container to not to release new docker image
 # on each new version of the storagenode binary.
-if [ ! -f "${BINARY_STORE}/storagenode-updater" ]; then
-  echo "downloading storagenode-updater"
-  get_binary storagenode-updater "$(get_default_url storagenode-updater minimum)"
-fi
-should_update storagenode-updater
-
-if [ ! -f "${BINARY_STORE}/storagenode" ]; then
-  echo "downloading storagenode"
-  get_binary storagenode "$(get_default_url storagenode minimum)"
-fi
-should_update storagenode
+for binary in storagenode-updater storagenode; do
+  if [ ! -f "${BINARY_STORE}/${binary}" ]; then
+    echo "downloading ${binary}"
+    get_binary ${binary} "$(get_default_url ${binary} minimum)"
+  fi
+  should_update ${binary}
+done
 
 SUPERVISOR_SERVER="${SUPERVISOR_SERVER:-unix}"
 


### PR DESCRIPTION
Related to #23

How to test:
* build the docker image:

```
docker buildx build -f Dockerfile -t node:latest .
```
* Create an image file and mount it with `noexec` to emulate a restricted mount:

```
truncate -s 100M temp.img
mkfs -t ext4 temp.img
mkdir temp-disk
sudo mount -o rw,noexec temp.img temp-disk
sudo chown $(id -i):$(id -g) temp-disk
```

## testing a normal flow
1. Run the container, and wait till the binaries are downloaded:
```
docker run --rm --name test --mount type=bind,source="${PWD}/test-disk",destination=/app/config node:latest
```
2. Check that there were no permission errors
3. Check that the `test-disk` contains both binaries in "test-disk/bin"
4. Rerun the container; binaries should not be downloaded again, and the container should be running without permission errors.

## storagenode has been updated in the ephemeral storage, but not in a persistent storage
1. download an old storagenode binary
```
wget -O /tmp/storagenode.zip https://github.com/storj/storj/releases/download/v1.111.4/storagenode_linux_amd64.zip
mkdir -p test-disk/bin
unzip -p /tmp/storagenode.zip > test-disk/bin/storagenode
chmod u+x test-disk/bin/storagenode
```
2. run the container
```
docker run --rm --name test --mount type=bind,source="${PWD}/test-disk",destination=/app/config node:latest
```
3. check that a new version of storagenode has been downloaded and replaced both in the persistent and ephemeral storages
4. check that there were no permissions errors
5. Check that the `test-disk` contains both binaries in "test-disk/bin"
6. Rerun the container; binaries should not be downloaded again, and the container should be running without permission errors.
7. Make sure, that the old version is updated to a minimum version, if the update to the suggested version is not allowed yet. 

## cleanup

```
sudo umount test-disk
rm -rf test-disk test.img
```