### PR TITLE
docker/entrypoint: support modular storagenode and separate version server for updater

### DIFF
--- a/docker/entrypoint
+++ b/docker/entrypoint
@@ -3,11 +3,12 @@ set -euo pipefail
 
 BINARY_DIR=/app/bin
 BINARY_STORE_DIR=${BINARY_STORE_DIR:-/app/config/bin}
+UPDATER_VERSION_SERVER_URL=${UPDATER_VERSION_SERVER_URL:-${VERSION_SERVER_URL:-https://version.storj.io}}
 
 get_default_url() {
   process=$1
   version=$2
-  wget -O- "${VERSION_SERVER_URL}/processes/${process}/${version}/url?os=linux&arch=${GOARCH}"
+  wget -O- "${UPDATER_VERSION_SERVER_URL}/processes/${process}/${version}/url?os=linux&arch=${GOARCH}"
 }
 
 copy_binary() {
@@ -33,7 +34,7 @@ should_update() {
     if ${BINARY_DIR}/storagenode-updater should-update ${binary} \
           --binary-location "${BINARY_DIR}/${binary}" \
           --identity-dir identity \
-          --version.server-address="${VERSION_SERVER_URL}" 2>/dev/null
+          --version.server-address="${UPDATER_VERSION_SERVER_URL}" 2>/dev/null
     then
       echo "downloading ${binary}"
       get_binary ${binary} "$(get_default_url ${binary} ${version})"
@@ -100,7 +101,7 @@ else
   /etc/supervisor/supervisord.conf
 
   sed -i \
-  "s#^command=/app/bin/storagenode\$#command=${BINARY_DIR}/storagenode run ${SNO_RUN_PARAMS} ${*}#" \
+  "s#^command=/app/bin/storagenode\$#command=${BINARY_DIR}/storagenode ${SNO_RUN_COMMAND:-run} ${SNO_RUN_PARAMS} ${*}#" \
   /etc/supervisor/supervisord.conf
 
   # remove explicit user flag when container is run as non-root


### PR DESCRIPTION
 * Add UPDATER_VERSION_SERVER_URL to allow using a different version server  for binary updates, while keeping VERSION_SERVER_URL for the storagenode runtime configuration.
 * Add SNO_RUN_COMMAND variable to allow overriding the default "run" subcommand, which is required for modular storagenode used by select.

Change-Id: I0d60b3ee3ef5743c467d4700f15b3e85aea560de
